### PR TITLE
Dockerfile: Keep container containing source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM golang:1.12.5-stretch as builder
 
+RUN apt-get update && \
+    apt-get install strace
+
 WORKDIR /app
 
 # Modules
@@ -10,11 +13,3 @@ COPY ./ ./
 
 # Build
 RUN go build -o issue-196 ./...
-
-FROM ubuntu:18.04
-COPY --from=builder /app/issue-196 /usr/local/bin
-
-RUN apt-get update && \
-    apt-get install -y strace
-
-CMD ["bash", "-c", "strace issue-196 2>&1 | grep newfstatat | wc -l"]


### PR DESCRIPTION
So the issue can be actually reproduced.

The issue only appears when packr is called from directory containing source code. this can be seen by running
```
docker run --cap-add SYS_PTRACE $(docker build . | tail -n1 | awk '{print $3}') sh -c 'echo -n "newfstatat syscalls from source directory: " && cd /app && strace -e newfstatat /app/issue-196 2>&1 | wc -l && echo -n "newfstatat syscalls from /tmp directory: " && cd /tmp && strace -e newfstatat /app/issue-196 2>&1 | wc -l'
```
with this PR.

Alternatively run:
```
docker run --cap-add SYS_PTRACE $(docker build . | tail -n1 | awk '{print $3}') sh -c 'cd /app && strace /app/issue-196 && cd /tmp && strace /app/issue-196'
```

to see full strace.